### PR TITLE
Add dependabot cooldown and open pr limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,4 @@ updates:
       interval: daily
     cooldown:
       default-days: 3
+    open-pull-requests-limit: 25

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     dependency-type: production
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
Adds a dependabot cooldown of 3 days and increases the upper limit on dependabot PRs to 25, as agreed in https://gov-uk.atlassian.net/browse/WHIT-3369

