### PR TITLE
Override js-yaml to 4.2.0 to fix DoS advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -349,13 +349,10 @@
       }
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.0",
@@ -1500,19 +1497,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/esquery": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
@@ -2614,14 +2598,22 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
-      "license": "MIT",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -4062,12 +4054,6 @@
       "version": "3.0.16",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz",
       "integrity": "sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==",
-      "dev": true
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
     "node_modules/standard": {

--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
       "Popup",
       "pluck"
     ]
+  },
+  "overrides": {
+    "js-yaml": "^4.2.0"
   }
 }


### PR DESCRIPTION
## What

Adds an npm `overrides` entry forcing `js-yaml` to `^4.2.0`.

## Why

Dependabot alert [#57](https://github.com/alphagov/govuk-browser-extension/security/dependabot/57) (`GHSA-h67p-54hq-rp68` / `CVE-2026-53550`): `js-yaml <= 4.1.1` has a quadratic-complexity DoS in merge-key (`<<`) handling — a crafted YAML document repeating the same alias can cause CPU exhaustion.

`js-yaml` is only present transitively, via `standardx → standard → eslint 7`, which pins `js-yaml 3.x`. There is no fix within the 3.x range (the advisory is only patched in `4.2.0`), so the override is the minimal way to pull the patched version while leaving the rest of the toolchain untouched. It's a dev/lint-only dependency.

## Note on future work

This is a deliberately small fix. The root cause is that **`standardx` is unmaintained** — its latest release still pins `eslint 7`, which is what drags in the old `js-yaml`. We will need to migrate off `standardx` at some point (e.g. to `neostandard`, the actively-maintained successor built on eslint 9), both to drop the override and to avoid being blocked on the next eslint-chain advisory. That migration is larger (new flat-config, a Node bump, full dependency-tree change) so it's intentionally kept out of this PR.

## Testing

- `npm run lint:js` — passes (0 errors/warnings)
- `npm test` — 78 specs, 0 failures
- `npm ls js-yaml` — resolves to `4.2.0`